### PR TITLE
Upgrade spaces dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ coveralls = { repository = "tspooner/lfa", branch = "master", service = "github"
 
 [dependencies]
 rand = "0.4"
-spaces = "1.0"
+spaces = "2.0"
 ndarray = "0.11"
 
 serde = "1.0"

--- a/src/projection/fourier.rs
+++ b/src/projection/fourier.rs
@@ -1,9 +1,8 @@
-use geometry::{BoundedSpace, RegularSpace, Space, Span, dimensions::Continuous, norms::l2};
-use utils::cartesian_product;
-use {Projection, Projector};
-
+use geometry::{BoundedSpace, RegularSpace, Space, Card, dimensions::Continuous, norms::l2};
 use rand::{ThreadRng, distributions::{IndependentSample, Range}};
 use std::f64::consts::PI;
+use utils::cartesian_product;
+use {Projection, Projector};
 
 // TODO: Add builder which allows use to configure whether to use coefficient
 // scaling or not.
@@ -73,7 +72,7 @@ impl Space for Fourier {
 
     fn dim(&self) -> usize { self.coefficients.len() }
 
-    fn span(&self) -> Span { Span::Infinite }
+    fn card(&self) -> Card { Card::Infinite }
 }
 
 impl Projector<[f64]> for Fourier {
@@ -133,7 +132,7 @@ mod tests {
         let f = Fourier::new(1, vec![(0.0, 1.0)]);
 
         assert_eq!(f.dim(), 1);
-        assert_eq!(f.span(), Span::Infinite);
+        assert_eq!(f.card(), Card::Infinite);
 
         assert!(
             f.project_expanded(&vec![-1.0])
@@ -180,7 +179,7 @@ mod tests {
         let f2 = Fourier::new(2, vec![(0.0, 1.0)]);
 
         assert_eq!(f2.dim(), f1.dim());
-        assert_eq!(f2.span(), f2.span());
+        assert_eq!(f2.card(), f2.card());
 
         assert_eq!(
             f2.project_expanded(&vec![-1.0]),
@@ -226,7 +225,7 @@ mod tests {
         let f = Fourier::new(1, vec![(0.0, 1.0), (5.0, 6.0)]);
 
         assert_eq!(f.dim(), 3);
-        assert_eq!(f.span(), Span::Infinite);
+        assert_eq!(f.card(), Card::Infinite);
 
         assert!(
             f.project_expanded(&vec![0.0, 5.0])
@@ -263,7 +262,7 @@ mod tests {
         let f = Fourier::new(2, vec![(0.0, 1.0), (5.0, 6.0)]);
 
         assert_eq!(f.dim(), 5);
-        assert_eq!(f.span(), Span::Infinite);
+        assert_eq!(f.card(), Card::Infinite);
 
         assert!(
             f.project_expanded(&vec![0.0, 5.0])

--- a/src/projection/polynomial/mod.rs
+++ b/src/projection/polynomial/mod.rs
@@ -1,8 +1,7 @@
-use super::{Projection, Projector};
-use geometry::{BoundedSpace, RegularSpace, Space, Span, Vector, dimensions::Continuous};
-use utils::cartesian_product;
-
+use geometry::{BoundedSpace, RegularSpace, Space, Card, Vector, dimensions::Continuous};
 use rand::ThreadRng;
+use super::{Projection, Projector};
+use utils::cartesian_product;
 
 mod cpfk;
 
@@ -50,7 +49,7 @@ impl Space for Polynomial {
 
     fn dim(&self) -> usize { self.exponents.len() }
 
-    fn span(&self) -> Span { Span::Infinite }
+    fn card(&self) -> Card { Card::Infinite }
 }
 
 impl Projector<[f64]> for Polynomial {
@@ -143,7 +142,7 @@ impl Space for Chebyshev {
 
     fn dim(&self) -> usize { self.polynomials.len() }
 
-    fn span(&self) -> Span { Span::Infinite }
+    fn card(&self) -> Card { Card::Infinite }
 }
 
 impl Projector<[f64]> for Chebyshev {

--- a/src/projection/rbf_network.rs
+++ b/src/projection/rbf_network.rs
@@ -1,9 +1,9 @@
-use super::{Projection, Projector};
-use geometry::{Matrix, RegularSpace, Space, Span, Vector, dimensions::Partitioned};
-use utils::cartesian_product;
-
+use geometry::{Matrix, RegularSpace, Space, Card, Vector, dimensions::Partitioned};
 use ndarray::Axis;
 use rand::ThreadRng;
+use super::{Projection, Projector};
+use utils::cartesian_product;
+
 
 /// Radial basis function network projector.
 #[derive(Clone, Serialize, Deserialize)]
@@ -29,8 +29,8 @@ impl RBFNetwork {
     }
 
     pub fn from_space(input_space: RegularSpace<Partitioned>) -> Self {
-        let n_features = match input_space.span() {
-            Span::Finite(s) => s,
+        let n_features = match input_space.card() {
+            Card::Finite(s) => s,
             _ => panic!("`RBFNetwork` projection only supports partitioned input spaces."),
         };
 
@@ -69,7 +69,7 @@ impl Space for RBFNetwork {
 
     fn dim(&self) -> usize { self.mu.rows() }
 
-    fn span(&self) -> Span { Span::Infinite }
+    fn card(&self) -> Card { Card::Infinite }
 }
 
 impl Projector<[f64]> for RBFNetwork {
@@ -82,7 +82,7 @@ mod tests {
     use ndarray::{arr1, arr2};
 
     #[test]
-    fn test_dim() {
+    fn test_dimensionality() {
         fn get_dim(rbf_net: RBFNetwork) -> usize { rbf_net.dim() }
 
         assert_eq!(get_dim(RBFNetwork::new(arr2(&[[0.0]]), arr1(&[0.25]))), 1);
@@ -101,24 +101,24 @@ mod tests {
     }
 
     #[test]
-    fn test_span() {
-        fn get_span(rbf_net: RBFNetwork) -> Span { rbf_net.span() }
+    fn test_cardinality() {
+        fn get_card(rbf_net: RBFNetwork) -> Card { rbf_net.card() }
 
         assert_eq!(
-            get_span(RBFNetwork::new(arr2(&[[0.0]]), arr1(&[0.25]))),
-            Span::Infinite
+            get_card(RBFNetwork::new(arr2(&[[0.0]]), arr1(&[0.25]))),
+            Card::Infinite
         );
         assert_eq!(
-            get_span(RBFNetwork::new(arr2(&[[0.0], [0.5], [1.0]]), arr1(&[0.25]))),
-            Span::Infinite
+            get_card(RBFNetwork::new(arr2(&[[0.0], [0.5], [1.0]]), arr1(&[0.25]))),
+            Card::Infinite
         );
         assert_eq!(
-            get_span(RBFNetwork::new(arr2(&vec![[0.0]; 10]), arr1(&[0.25]))),
-            Span::Infinite
+            get_card(RBFNetwork::new(arr2(&vec![[0.0]; 10]), arr1(&[0.25]))),
+            Card::Infinite
         );
         assert_eq!(
-            get_span(RBFNetwork::new(arr2(&vec![[0.0]; 100]), arr1(&[0.25]))),
-            Span::Infinite
+            get_card(RBFNetwork::new(arr2(&vec![[0.0]; 100]), arr1(&[0.25]))),
+            Card::Infinite
         );
     }
 

--- a/src/projection/tile_coding.rs
+++ b/src/projection/tile_coding.rs
@@ -1,8 +1,7 @@
-use super::{Projection, Projector};
-use geometry::{Space, Span};
-
+use geometry::{Space, Card};
 use rand::{ThreadRng, seq::sample_indices};
 use std::hash::{BuildHasher, Hasher};
+use super::{Projection, Projector};
 
 #[inline]
 fn bin_state(input: &[f64], n_tilings: usize) -> Vec<usize> {
@@ -61,7 +60,7 @@ impl<H: BuildHasher> Space for TileCoding<H> {
 
     fn dim(&self) -> usize { self.memory_size }
 
-    fn span(&self) -> Span { unimplemented!() }
+    fn card(&self) -> Card { unimplemented!() }
 }
 
 impl<H: BuildHasher> Projector<[f64]> for TileCoding<H> {

--- a/src/projection/uniform_grid.rs
+++ b/src/projection/uniform_grid.rs
@@ -1,7 +1,7 @@
-use super::{Projection, Projector};
-use geometry::{RegularSpace, Space, Span, Surjection, dimensions::Partitioned};
-
+use geometry::{RegularSpace, Space, Card, Surjection, dimensions::Partitioned};
 use rand::{ThreadRng, seq::sample_indices};
+use super::{Projection, Projector};
+
 
 /// Fixed uniform basis projector.
 #[derive(Clone, Serialize, Deserialize)]
@@ -12,7 +12,7 @@ pub struct UniformGrid {
 
 impl UniformGrid {
     pub fn new(input_space: RegularSpace<Partitioned>) -> Self {
-        let n_features = input_space.span().into();
+        let n_features = input_space.card().into();
 
         UniformGrid {
             n_features: n_features,
@@ -40,7 +40,7 @@ impl Space for UniformGrid {
 
     fn dim(&self) -> usize { self.n_features }
 
-    fn span(&self) -> Span { unimplemented!() }
+    fn card(&self) -> Card { unimplemented!() }
 }
 
 impl Projector<[f64]> for UniformGrid {


### PR DESCRIPTION
The changes to spaces crate require that every implementor of `Space` replace the method `span` with `card`. This represents a change in our API and thus a breaking change to the crate.

This PR also addresses inconsistencies between uses and implementations of the `Space::dim` method across crates and modules.