### PR TITLE
Parameterised trait

### DIFF
--- a/src/approximators/mod.rs
+++ b/src/approximators/mod.rs
@@ -1,42 +1,5 @@
-use error::*;
-use projectors::{IndexSet, IndexT};
-use std::collections::HashMap;
-
 mod simple;
 pub use self::simple::Simple;
 
 mod multi;
 pub use self::multi::Multi;
-
-/// An interface for function approximators.
-pub trait Approximator<I: ?Sized> {
-    type Value;
-
-    /// Evaluate the function and return its value.
-    fn evaluate(&self, input: &I) -> EvaluationResult<Self::Value>;
-
-    /// Update the approximator's estimate for the given input.
-    fn update(&mut self, input: &I, update: Self::Value) -> UpdateResult<()>;
-
-    #[allow(unused_variables)]
-    /// Adapt the approximator in light of newly discovered features.
-    fn adapt(&mut self, new_features: &HashMap<IndexT, IndexSet>) -> AdaptResult<usize> {
-        Err(AdaptError::NotImplemented)
-    }
-}
-
-impl<I: ?Sized, T: Approximator<I>> Approximator<I> for Box<T> {
-    type Value = T::Value;
-
-    fn evaluate(&self, input: &I) -> EvaluationResult<Self::Value> {
-        (**self).evaluate(input)
-    }
-
-    fn update(&mut self, input: &I, update: Self::Value) -> UpdateResult<()> {
-        (**self).update(input, update)
-    }
-
-    fn adapt(&mut self, new_features: &HashMap<IndexT, IndexSet>) -> AdaptResult<usize> {
-        (**self).adapt(new_features)
-    }
-}

--- a/src/approximators/multi.rs
+++ b/src/approximators/multi.rs
@@ -1,4 +1,4 @@
-use approximators::Approximator;
+use core::Approximator;
 use error::AdaptError;
 use geometry::{Matrix, Vector};
 use projectors::{IndexSet, IndexT, Projection};

--- a/src/approximators/multi.rs
+++ b/src/approximators/multi.rs
@@ -118,11 +118,11 @@ mod tests {
     extern crate seahash;
 
     use LFA;
-    use approximators::{Approximator, Multi};
+    use approximators::Multi;
+    use core::Approximator;
     use geometry::Vector;
     use projectors::fixed::{Fourier, TileCoding};
-    use std::collections::{BTreeSet, HashMap};
-    use std::hash::BuildHasherDefault;
+    use std::{collections::{BTreeSet, HashMap}, hash::BuildHasherDefault};
 
     type SHBuilder = BuildHasherDefault<seahash::SeaHasher>;
 

--- a/src/approximators/multi.rs
+++ b/src/approximators/multi.rs
@@ -1,10 +1,8 @@
-use core::Approximator;
-use error::AdaptError;
+use core::{Approximator, Parameterised};
+use error::{AdaptError, AdaptResult, EvaluationResult, UpdateResult};
 use geometry::{Matrix, Vector};
 use projectors::{IndexSet, IndexT, Projection};
-use std::collections::HashMap;
-use std::mem::replace;
-use {AdaptResult, EvaluationResult, UpdateResult};
+use std::{collections::HashMap, mem::replace};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Multi {
@@ -106,6 +104,12 @@ impl Approximator<Projection> for Multi {
             }
             Err(err) => Err(err),
         }
+    }
+}
+
+impl Parameterised for Multi {
+    fn weights(&self) -> Matrix<f64> {
+        self.weights.clone()
     }
 }
 

--- a/src/approximators/simple.rs
+++ b/src/approximators/simple.rs
@@ -1,4 +1,4 @@
-use approximators::Approximator;
+use core::Approximator;
 use error::AdaptError;
 use geometry::Vector;
 use projectors::{IndexSet, IndexT, Projection};

--- a/src/approximators/simple.rs
+++ b/src/approximators/simple.rs
@@ -83,10 +83,10 @@ mod tests {
     extern crate seahash;
 
     use LFA;
-    use approximators::{Approximator, Simple};
+    use approximators::Simple;
+    use core::Approximator;
     use projectors::fixed::{Fourier, TileCoding};
-    use std::collections::{BTreeSet, HashMap};
-    use std::hash::BuildHasherDefault;
+    use std::{collections::{BTreeSet, HashMap}, hash::BuildHasherDefault};
 
     type SHBuilder = BuildHasherDefault<seahash::SeaHasher>;
 

--- a/src/approximators/simple.rs
+++ b/src/approximators/simple.rs
@@ -1,10 +1,8 @@
-use core::Approximator;
-use error::AdaptError;
-use geometry::Vector;
+use core::{Approximator, Parameterised};
+use error::{AdaptError, AdaptResult, EvaluationResult, UpdateResult};
+use geometry::{Matrix, Vector};
 use projectors::{IndexSet, IndexT, Projection};
-use std::collections::HashMap;
-use std::mem::replace;
-use {AdaptResult, EvaluationResult, UpdateResult};
+use std::{collections::HashMap, mem::replace};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Simple {
@@ -69,6 +67,14 @@ impl Approximator<Projection> for Simple {
         self.extend_weights(new_weights?);
 
         Ok(n_nfs)
+    }
+}
+
+impl Parameterised for Simple {
+    fn weights(&self) -> Matrix<f64> {
+        let n_rows = self.weights.len();
+
+        self.weights.clone().into_shape((n_rows, 1)).unwrap()
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,0 +1,36 @@
+use error::*;
+use projectors::{IndexSet, IndexT};
+use std::collections::HashMap;
+
+/// An interface for function approximators.
+pub trait Approximator<I: ?Sized> {
+    type Value;
+
+    /// Evaluate the function and return its value.
+    fn evaluate(&self, input: &I) -> EvaluationResult<Self::Value>;
+
+    /// Update the approximator's estimate for the given input.
+    fn update(&mut self, input: &I, update: Self::Value) -> UpdateResult<()>;
+
+    #[allow(unused_variables)]
+    /// Adapt the approximator in light of newly discovered features.
+    fn adapt(&mut self, new_features: &HashMap<IndexT, IndexSet>) -> AdaptResult<usize> {
+        Err(AdaptError::NotImplemented)
+    }
+}
+
+impl<I: ?Sized, T: Approximator<I>> Approximator<I> for Box<T> {
+    type Value = T::Value;
+
+    fn evaluate(&self, input: &I) -> EvaluationResult<Self::Value> {
+        (**self).evaluate(input)
+    }
+
+    fn update(&mut self, input: &I, update: Self::Value) -> UpdateResult<()> {
+        (**self).update(input, update)
+    }
+
+    fn adapt(&mut self, new_features: &HashMap<IndexT, IndexSet>) -> AdaptResult<usize> {
+        (**self).adapt(new_features)
+    }
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,4 +1,5 @@
 use error::*;
+use geometry::Matrix;
 use projectors::{IndexSet, IndexT};
 use std::collections::HashMap;
 
@@ -32,5 +33,17 @@ impl<I: ?Sized, T: Approximator<I>> Approximator<I> for Box<T> {
 
     fn adapt(&mut self, new_features: &HashMap<IndexT, IndexSet>) -> AdaptResult<usize> {
         (**self).adapt(new_features)
+    }
+}
+
+/// An interface for approximators parameterised by a set of weights.
+pub trait Parameterised {
+    /// Return a copy of the approximator weights.
+    fn weights(&self) -> Matrix<f64>;
+}
+
+impl<T: Parameterised> Parameterised for Box<T> {
+    fn weights(&self) -> Matrix<f64> {
+        (**self).weights()
     }
 }

--- a/src/lfa.rs
+++ b/src/lfa.rs
@@ -1,4 +1,5 @@
-use approximators::{Approximator, Multi, Simple};
+use approximators::{Multi, Simple};
+use core::Approximator;
 use error::*;
 use projectors::{IndexSet, IndexT, Projection, Projector};
 use std::collections::HashMap;

--- a/src/lfa.rs
+++ b/src/lfa.rs
@@ -1,9 +1,9 @@
 use approximators::{Multi, Simple};
-use core::Approximator;
+use core::{Approximator, Parameterised};
 use error::*;
+use geometry::Matrix;
 use projectors::{IndexSet, IndexT, Projection, Projector};
-use std::collections::HashMap;
-use std::marker::PhantomData;
+use std::{collections::HashMap, marker::PhantomData};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct LFA<I: ?Sized, P: Projector<I>, A: Approximator<Projection>> {
@@ -60,5 +60,16 @@ impl<I: ?Sized, P: Projector<I>, A: Approximator<Projection>> Approximator<I> fo
 
     fn adapt(&mut self, new_features: &HashMap<IndexT, IndexSet>) -> AdaptResult<usize> {
         self.approximator.adapt(new_features)
+    }
+}
+
+impl<I, P, A> Parameterised for LFA<I, P, A>
+where
+    I: ?Sized,
+    P: Projector<I>,
+    A: Approximator<Projection> + Parameterised,
+{
+    fn weights(&self) -> Matrix<f64> {
+        self.approximator.weights()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,15 @@ extern crate serde;
 extern crate serde_derive;
 
 mod utils;
-
 mod error;
 pub use self::error::*;
 
-pub mod projectors;
-pub use self::projectors::{AdaptiveProjector, Projection, Projector};
+pub mod core;
+pub use self::core::*;
 
 pub mod approximators;
-pub use self::approximators::Approximator;
+pub mod projectors;
+pub use self::projectors::{AdaptiveProjector, Projection, Projector};
 
 mod lfa;
 pub use self::lfa::LFA;


### PR DESCRIPTION
We introduce a new trait called "Parameterised" which has only one method, "weights". We have needed a simple way to extract the weight matrices for a while now. We probably didn't have to have a trait for this, but it will actually be useful for use in other crates too and it's nice to have the interoperability.