### PR TITLE
Add `Parameterised::n_weights()` method

### DIFF
--- a/src/approximators/pair.rs
+++ b/src/approximators/pair.rs
@@ -71,6 +71,8 @@ impl Approximator<Projection> for PairFunction {
 
 impl Parameterised for PairFunction {
     fn weights(&self) -> Matrix<f64> { self.weights.clone() }
+
+    fn n_weights(&self) -> usize { self.weights.len() }
 }
 
 #[cfg(test)]

--- a/src/approximators/scalar.rs
+++ b/src/approximators/scalar.rs
@@ -78,6 +78,8 @@ impl Parameterised for ScalarFunction {
 
         self.weights.clone().into_shape((n_rows, 1)).unwrap()
     }
+
+    fn n_weights(&self) -> usize { self.weights.len() }
 }
 
 #[cfg(test)]

--- a/src/approximators/triple.rs
+++ b/src/approximators/triple.rs
@@ -75,6 +75,8 @@ impl Approximator<Projection> for TripleFunction {
 
 impl Parameterised for TripleFunction {
     fn weights(&self) -> Matrix<f64> { self.weights.clone() }
+
+    fn n_weights(&self) -> usize { self.weights.len() }
 }
 
 #[cfg(test)]

--- a/src/approximators/vector.rs
+++ b/src/approximators/vector.rs
@@ -62,6 +62,8 @@ impl Approximator<Projection> for VectorFunction {
 
 impl Parameterised for VectorFunction {
     fn weights(&self) -> Matrix<f64> { self.weights.clone() }
+
+    fn n_weights(&self) -> usize { self.weights.len() }
 }
 
 #[cfg(test)]

--- a/src/core/parameterised.rs
+++ b/src/core/parameterised.rs
@@ -4,8 +4,13 @@ use crate::geometry::Matrix;
 pub trait Parameterised {
     /// Return a copy of the approximator weights.
     fn weights(&self) -> Matrix<f64>;
+
+    /// Returns the total number of weights.
+    fn n_weights(&self) -> usize { self.weights().len() }
 }
 
 impl<T: Parameterised> Parameterised for Box<T> {
     fn weights(&self) -> Matrix<f64> { (**self).weights() }
+
+    fn n_weights(&self) -> usize { (**self).n_weights() }
 }

--- a/src/lfa.rs
+++ b/src/lfa.rs
@@ -1,7 +1,9 @@
-use crate::approximators::*;
-use crate::basis::{AdaptiveProjector, CandidateFeature, Projection, Projector};
-use crate::core::*;
-use crate::geometry::{Card, Matrix, Space};
+use crate::{
+    approximators::*,
+    basis::{Projection, Projector},
+    core::*,
+    geometry::{Matrix, Space}
+};
 use std::collections::HashMap;
 
 macro_rules! impl_concrete_builder {
@@ -91,4 +93,6 @@ where
 
 impl<P, A: Parameterised> Parameterised for LFA<P, A> {
     fn weights(&self) -> Matrix<f64> { self.approximator.weights() }
+
+    fn n_weights(&self) -> usize { self.approximator.n_weights() }
 }


### PR DESCRIPTION
Up to now you would have to call `x.weights().len()` which incurs a clone of the weight matrix just to compute the length! While we leave this as a default so we don't break code, this allows someone to implement a more sensible implementation.