### PR TITLE
New manifest feature: "serialize"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ documentation = "https://docs.rs/lfa"
 travis-ci = { repository = "tspooner/lfa", branch = "master" }
 coveralls = { repository = "tspooner/lfa", branch = "master", service = "github" }
 
+[features]
+default = []
+
+serialize = ["serde", "serde_derive"]
+
 [dependencies]
 rand = "0.6"
 spaces = "4.5"
@@ -25,8 +30,8 @@ ndarray = "0.12"
 itertools = "0.8"
 elementwise = "0.3"
 
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.7"

--- a/src/basis/fixed/constant.rs
+++ b/src/basis/fixed/constant.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 
 /// Fixed uniform basis projector.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Constant {
     n_features: usize,
     value: f64,
@@ -37,7 +38,8 @@ impl<I: ?Sized> Projector<I> for Constant {
 }
 
 /// Fixed uniform basis projector.
-#[derive(Clone)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct Indices {
     n_features: usize,
     active_features: Vec<usize>,

--- a/src/basis/fixed/fourier.rs
+++ b/src/basis/fixed/fourier.rs
@@ -20,7 +20,8 @@ use std::f64::consts::PI;
 /// - [Konidaris, George, Sarah Osentoski, and Philip S. Thomas. "Value
 /// function approximation in reinforcement learning using the Fourier basis."
 /// AAAI. Vol. 6. 2011.](http://lis.csail.mit.edu/pubs/konidaris-aaai11a.pdf)
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct Fourier {
     pub order: u8,
     pub limits: Vec<(f64, f64)>,

--- a/src/basis/fixed/kernelised.rs
+++ b/src/basis/fixed/kernelised.rs
@@ -12,7 +12,8 @@ use crate::{
 };
 
 /// Feature prototype used by the `KernelProjector` basis.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct Prototype<I, K> {
     pub centroid: I,
     pub kernel: K,
@@ -23,7 +24,8 @@ impl<I, K: Kernel<I>> Prototype<I, K> {
 }
 
 /// Kernel machine basis projector.
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct KernelProjector<I, K> {
     pub prototypes: Vec<Prototype<I, K>>,
 }

--- a/src/basis/fixed/polynomial/mod.rs
+++ b/src/basis/fixed/polynomial/mod.rs
@@ -41,7 +41,8 @@ mod cpfk;
 /// assert_eq!(p.project(&vec![0.75]), vec![0.5, 0.25].into());
 /// assert_eq!(p.project(&vec![1.00]), vec![1.0, 1.0].into());
 /// ```
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct Polynomial {
     pub order: u8,
     pub limits: Vec<(f64, f64)>,
@@ -117,6 +118,7 @@ impl Projector<[f64]> for Polynomial {
 impl_array_proxies!(Polynomial; f64);
 
 /// Chebyshev polynomial basis projector.
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Chebyshev {
     pub order: u8,

--- a/src/basis/fixed/random.rs
+++ b/src/basis/fixed/random.rs
@@ -9,7 +9,8 @@ use rand::{
 };
 
 /// Fixed uniform basis projector.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Random<D: Distribution<f64>> {
     n_features: usize,
     distribution: D,

--- a/src/basis/fixed/tile_coding.rs
+++ b/src/basis/fixed/tile_coding.rs
@@ -39,7 +39,8 @@ fn hash_state<H: Hasher>(
 }
 
 /// Generalised tile coding scheme with hashing.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct TileCoding<H> {
     hasher_builder: H,
     n_tilings: usize,

--- a/src/basis/fixed/uniform_grid.rs
+++ b/src/basis/fixed/uniform_grid.rs
@@ -12,7 +12,8 @@ use crate::{
 };
 
 /// Fixed uniform basis projector.
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct UniformGrid {
     n_features: usize,
     feature_space: LinearSpace<Partition>,

--- a/src/basis/ifdd.rs
+++ b/src/basis/ifdd.rs
@@ -10,7 +10,8 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Feature {
     pub index: usize,
     pub parent_indices: IndexSet,
@@ -29,7 +30,8 @@ impl Hash for Feature {
     fn hash<H: Hasher>(&self, state: &mut H) { self.index.hash(state); }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CandidateFeature {
     pub relevance: f64,
     pub parent_indices: IndexSet,
@@ -71,7 +73,8 @@ impl PartialOrd for CandidateFeature {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct IFDD<P> {
     pub base: P,
     pub features: Vec<Feature>,

--- a/src/basis/projector.rs
+++ b/src/basis/projector.rs
@@ -1,5 +1,4 @@
 use crate::{
-    composition::Composable,
     core::{DenseT, Features},
     geometry::Space,
 };
@@ -42,7 +41,6 @@ pub trait Projector<I: ?Sized>: Space<Value = Features> {
     fn project_expanded(&self, input: &I) -> DenseT { self.project(input).expanded(self.dim()) }
 }
 
-// #[macro_export]
 macro_rules! impl_array_proxy {
     ([$itype:ty; $($n:expr),*] for $type:ty) => {
         $(
@@ -74,7 +72,6 @@ macro_rules! impl_array_proxy {
     };
 }
 
-// #[macro_export]
 macro_rules! impl_array_proxies {
     ($type:ty; $($itype:ty),*) => {
         $(

--- a/src/composition/arithmetic.rs
+++ b/src/composition/arithmetic.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 
 /// Apply negation to the output.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Negate<T>(T);
 
 impl<T> Negate<T> {
@@ -27,7 +28,8 @@ impl<I: ?Sized, P: Projector<I>> Projector<I> for Negate<P> {
 }
 
 /// Sum the output of two `Projector` instances.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Sum<T1, T2>(T1, T2);
 
 impl<T1, T2> Sum<T1, T2> {
@@ -70,7 +72,8 @@ impl<I: ?Sized, P1: Projector<I>, P2: Projector<I>> Projector<I> for Sum<P1, P2>
 }
 
 /// Apply inversion to the output of a `Projector` instance.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Reciprocal<P>(P);
 
 impl<P: Space> Reciprocal<P> {
@@ -99,7 +102,8 @@ impl<I: ?Sized, P: Projector<I>> Projector<I> for Reciprocal<P> {
 }
 
 /// Multiply the output of two `Projector` instances.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Product<P1, P2> {
     p1: P1,
     p2: P2,

--- a/src/composition/normalisation.rs
+++ b/src/composition/normalisation.rs
@@ -9,7 +9,8 @@ use crate::{
 };
 
 /// Apply _L₁_ normalisation to the output of a `Projector` instance.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct L1Normalise<P>(P);
 
 impl<P> L1Normalise<P> {
@@ -36,7 +37,8 @@ impl<I: ?Sized, P: Projector<I>> Projector<I> for L1Normalise<P> {
 }
 
 /// Apply _L₂_ normalisation to the output of a `Projector` instance.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct L2Normalise<P>(P);
 
 impl<P> L2Normalise<P> {
@@ -63,7 +65,8 @@ impl<I: ?Sized, P: Projector<I>> Projector<I> for L2Normalise<P> {
 }
 
 /// Apply _Lp_ normalisation to the output of a `Projector` instance.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct LpNormalise<P>(P, u8);
 
 impl<P> LpNormalise<P> {
@@ -90,7 +93,8 @@ impl<I: ?Sized, P: Projector<I>> Projector<I> for LpNormalise<P> {
 }
 
 /// Apply _L∞_ normalisation to the output of a `Projector` instance.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct LinfNormalise<P>(P);
 
 impl<P> LinfNormalise<P> {

--- a/src/composition/scaling.rs
+++ b/src/composition/scaling.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 
 /// Scale the output of a `Projector` instance by some fixed amount.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Scale<P> {
     projector: P,
     scale: f64,

--- a/src/composition/shifting.rs
+++ b/src/composition/shifting.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 
 /// Shift the output of a `Projector` instance by some fixed amount.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Shift<P> {
     projector: P,
     offset: f64,

--- a/src/composition/stack.rs
+++ b/src/composition/stack.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 
 /// Stack the output of two `Projector` instances.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Stack<P1, P2> {
     p1: P1,
     p2: P2,

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -1,11 +1,11 @@
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum EvaluationError {
     Failed,
 }
 
 pub type EvaluationResult<T> = Result<T, EvaluationError>;
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum UpdateError {
     Failed,
 }

--- a/src/core/features.rs
+++ b/src/core/features.rs
@@ -71,7 +71,8 @@ macro_rules! apply_to_dense_or_sparse {
 }
 
 /// Projected feature vector representation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub enum Features {
     /// Dense, floating-point activation vector.
     Dense(DenseT),

--- a/src/eval/pair.rs
+++ b/src/eval/pair.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 
 /// Weight-`Projection` evaluator with pair `[f64; 2]` output.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct PairFunction {
     pub weights: Matrix<f64>,
 }

--- a/src/eval/scalar.rs
+++ b/src/eval/scalar.rs
@@ -5,7 +5,8 @@ use crate::{
 use ndarray::Axis;
 
 /// Weight-`Features` evaluator with scalar `f64` output.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct ScalarFunction {
     pub weights: Vector<f64>,
 }

--- a/src/eval/triple.rs
+++ b/src/eval/triple.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 
 /// Weight-`Projection` evaluator with triple `[f64; 3]` output.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct TripleFunction {
     pub weights: Matrix<f64>,
 }

--- a/src/eval/vector.rs
+++ b/src/eval/vector.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 
 /// Weight-`Projection` evaluator with vector `Vector<f64>` output.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug)]
 pub struct VectorFunction {
     pub weights: Matrix<f64>,
 }

--- a/src/lfa/transformed.rs
+++ b/src/lfa/transformed.rs
@@ -20,7 +20,8 @@ macro_rules! impl_builder {
 }
 
 /// Transformed linear function approximator.
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct TransformedLFA<P, E, T = Identity> {
     pub projector: P,
     pub evaluator: E,

--- a/src/lfa/vanilla.rs
+++ b/src/lfa/vanilla.rs
@@ -26,7 +26,8 @@ impl_builder!(PairFunction => pair);
 impl_builder!(TripleFunction => triple);
 
 /// Linear function approximator.
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct LFA<P, E> {
     pub projector: P,
     pub evaluator: E,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-#[macro_use]
 extern crate ndarray;
 extern crate rand;
 extern crate itertools;
 extern crate elementwise;
 
-extern crate serde;
-#[macro_use]
+#[cfg(feature = "serialize")] extern crate serde;
+#[cfg_attr(feature = "serialize", macro_use)]
+#[cfg(feature = "serialize")]
 extern crate serde_derive;
 
 #[cfg(tests)]

--- a/src/transforms/exponential.rs
+++ b/src/transforms/exponential.rs
@@ -2,6 +2,8 @@ use crate::geometry::Vector;
 use super::Transform;
 
 // f(x) ≜ exp(x)
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Exp;
 
 impl Transform<f64> for Exp {

--- a/src/transforms/identity.rs
+++ b/src/transforms/identity.rs
@@ -2,6 +2,8 @@ use geometry::Vector;
 use super::Transform;
 
 // f(x) ≜ x
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Identity;
 
 macro_rules! impl_identity {

--- a/src/transforms/logistic.rs
+++ b/src/transforms/logistic.rs
@@ -2,6 +2,8 @@ use crate::geometry::Vector;
 use super::Transform;
 
 // f(x) ≜ L / (1 + exp(-k(x - x0))
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Logistic {
     amplitude: f64,
     growth_rate: f64,

--- a/src/transforms/softplus.rs
+++ b/src/transforms/softplus.rs
@@ -2,6 +2,8 @@ use crate::geometry::Vector;
 use super::{Transform, Logistic};
 
 // f(x) ≜ log(1 + exp(x))
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct Softplus;
 
 impl Transform<f64> for Softplus {
@@ -61,6 +63,8 @@ impl Transform<Vector<f64>> for Softplus {
 }
 
 // f(x, y, ...) ≜ log(C + exp(x) + exp(y) + ...)
+#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, Debug)]
 pub struct LogSumExp(f64);
 
 impl LogSumExp {


### PR DESCRIPTION
This is dead simple, just put all the implementations of serde under an optional crate feature called "serialize" (I'd rather the english spelling but people will probably just get confused). May help with compilation times etc etc...